### PR TITLE
Fix GitHub Actions commit retrieval

### DIFF
--- a/.github/workflows/download-vscode-server.yml
+++ b/.github/workflows/download-vscode-server.yml
@@ -24,7 +24,7 @@ jobs:
       - name: 获取最新 VS Code commit ID
         id: get_commit
         run: |
-          COMMIT_ID=$(curl -s https://update.code.visualstudio.com/api/commits/stable | jq -r '.commit')
+          COMMIT_ID=$(curl -s https://update.code.visualstudio.com/api/update/linux-x64/stable/latest | jq -r '.version')
           echo "commit_id=$COMMIT_ID" >> $GITHUB_OUTPUT
 
       - name: 下载并打包 VS Code Server


### PR DESCRIPTION
## Summary
- fix URL used to fetch the latest VS Code commit id

## Testing
- `shellcheck download_server.sh`
- `bash -n download_server.sh`


------
https://chatgpt.com/codex/tasks/task_b_684156443c00832ea01acb204de90f24