### PR TITLE
Fix long tag name for release

### DIFF
--- a/.github/workflows/download-vscode-server.yml
+++ b/.github/workflows/download-vscode-server.yml
@@ -10,12 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       commit_id: ${{ steps.get_commit.outputs.commit_id }}
+      commit_short: ${{ steps.get_commit.outputs.commit_short }}
     steps:
       - name: 获取最新 VS Code commit ID
         id: get_commit
         run: |
           COMMIT_ID=$(curl -s https://update.code.visualstudio.com/api/update/linux-x64/stable/latest | jq -r '.version')
+          COMMIT_SHORT=${COMMIT_ID:0:7}
           echo "commit_id=$COMMIT_ID" >> $GITHUB_OUTPUT
+          echo "commit_short=$COMMIT_SHORT" >> $GITHUB_OUTPUT
 
   build:
     needs: prepare
@@ -67,8 +70,8 @@ jobs:
       - name: 发布 Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ needs.prepare.outputs.commit_id }}
-          name: ${{ needs.prepare.outputs.commit_id }}
+          tag_name: vscode-server-${{ needs.prepare.outputs.commit_short }}
+          name: vscode-server-${{ needs.prepare.outputs.commit_id }}
           files: |
             artifacts/vscode-server-${{ needs.prepare.outputs.commit_id }}-x64.tar.gz
             artifacts/vscode-server-${{ needs.prepare.outputs.commit_id }}-arm64.tar.gz


### PR DESCRIPTION
## Summary
- shorten GitHub release tag names using a commit short hash

## Testing
- `yamllint .github/workflows/download-vscode-server.yml`

------
https://chatgpt.com/codex/tasks/task_b_684161796a20832e949c65cc18c30d88